### PR TITLE
Break out ZK Servers and Apache mirror into variables with default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Oracle Java 8 JDK role from Ansible Galaxy can be used if one is needed.
 
 ## Role Variables
 
-    zookeeper_version: 3.4.8
+    zookeeper_version: 3.4.13
     zookeeper_group: zookeeper
     zookeeper_user: zookeeper
     zookeeper_root_dir: /usr/share
@@ -32,6 +32,8 @@ The Oracle Java 8 JDK role from Ansible Galaxy can be used if one is needed.
     zookeeper_id: 1
     zookeeper_leader_port: 2888
     zookeeper_election_port: 3888
+    zookeeper_mirror: "http://www-eu.apache.org/dist/zookeeper"
+    zookeeper_servers: "{{groups['zookeeper-nodes']}}"
 
 
 ### Default Ports

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
-
-zookeeper_version: 3.4.12
+zookeeper_mirror: "http://www-eu.apache.org/dist/zookeeper"
+zookeeper_version: 3.4.13
 
 zookeeper_group: zookeeper
 zookeeper_user: zookeeper
@@ -23,3 +23,5 @@ zookeeper_id: 1
 
 zookeeper_leader_port: 2888
 zookeeper_election_port: 3888
+
+zookeeper_servers: "{{groups['zookeeper-nodes']}}"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,5 +1,4 @@
 ---
-
 - name: Create zookeeper group
   group:
     name: '{{ zookeeper_group }}'
@@ -23,7 +22,7 @@
 
 - name: Download Apache ZooKeeper
   get_url:
-    url: http://www-eu.apache.org/dist/zookeeper/zookeeper-{{ zookeeper_version }}/zookeeper-{{ zookeeper_version }}.tar.gz
+    url: "{{zookeeper_mirror}}/zookeeper-{{ zookeeper_version }}/zookeeper-{{ zookeeper_version }}.tar.gz"
     dest: /tmp
   when: dir.stat.exists == False
   tags:

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -47,6 +47,6 @@ clientPort={{ zookeeper_client_port }}
 #server.1=hostname1:2888:3888
 #server.2=hostname2:2888:3888
 
-{% for host in groups['zookeeper-nodes'] %}
-server.{{ hostvars[host].zookeeper_id }}={{ hostvars[host]['ansible_host'] }}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
+{% for host in zookeeper_servers %}
+server.{{ hostvars[host].zookeeper_id }}={{ hostvars[host]['ansible_nodename'] }}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
 {% endfor %}


### PR DESCRIPTION
This moves the hard coded values for the apache mirror address and ZK server array to optional variables. To allow more customizability of role usage.