### PR TITLE
Environment vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,16 @@ The Oracle Java 8 JDK role from Ansible Galaxy can be used if one is needed.
 
 ### Default Directories and Files
 
-| Directory / File | |
-|-----|----|
-| Installation directory | `/usr/share/zookeeper-<version>`
-| Symlink to install directory | `/usr/share/zookeeper` |
-| Symlink to configuration | `/etc/zookeeper/zoo.cfg` |
-| Log files | `/var/log/zookeeper` |
-| Data directory for snapshots and myid file | `/var/lib/zookeeper` |
-| Data directory for transaction log files | `/var/lib/zookeeper` |
-| Systemd service | `/usr/lib/systemd/system/zookeeper.service` |
+ Description                               | Directory / File 
+-------------------------------------------|------------------
+Installation directory                     | `/usr/share/zookeeper-<version>`
+Symlink to install directory               | `/usr/share/zookeeper` 
+Symlink to configuration                   | `/etc/zookeeper/zoo.cfg` 
+Log files                                  | `/var/log/zookeeper` 
+Data directory for snapshots and myid file | `/var/lib/zookeeper` 
+Data directory for transaction log files   | `/var/lib/zookeeper` 
+Systemd service                            | `/usr/lib/systemd/system/zookeeper.service` 
+System Defaults                            | `/etc/default/zookeeper` 
 
 ## Starting and Stopping ZooKeeper services
 * The ZooKeeper service can be started via: `systemctl start zookeeper`

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The Oracle Java 8 JDK role from Ansible Galaxy can be used if one is needed.
     zookeeper_election_port: 3888
     zookeeper_mirror: "http://www-eu.apache.org/dist/zookeeper"
     zookeeper_servers: "{{groups['zookeeper-nodes']}}"
+    zookeeper_environment:
+        "JVMFLAGS": "-javaagent:/opt/jolokia/jolokia-jvm-1.6.0-agent.jar"
 
 
 ### Default Ports

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -25,3 +25,4 @@ zookeeper_leader_port: 2888
 zookeeper_election_port: 3888
 
 zookeeper_servers: "{{groups['zookeeper-nodes']}}"
+zookeeper_environment: {}

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -114,6 +114,15 @@
   tags:
     - zookeeper_config
 
+- name: Template /etc/default
+  template:
+    src: default.j2
+    dest: '/etc/default/zookeeper'
+  notify:
+    - Restart ZooKeeper service
+  tags:
+    - zookeeper_config
+
 # Uncomment the log4j.properties line for setting the maximum number of logs to rollover and keep
 - name: Set maximum log rollover history
   replace:

--- a/templates/default.j2
+++ b/templates/default.j2
@@ -1,6 +1,6 @@
 ZOO_LOG_DIR={{ zookeeper_log_dir }}
 ZOO_LOG4J_PROP=INFO,ROLLINGFILE
 
-{% for key, value in zookeeper_environment.iteritems() %}
+{% for key, value in zookeeper_environment.items() %}
 {{key}}={{value}}
 {% endfor %}

--- a/templates/default.j2
+++ b/templates/default.j2
@@ -1,0 +1,6 @@
+ZOO_LOG_DIR={{ zookeeper_log_dir }}
+ZOO_LOG4J_PROP=INFO,ROLLINGFILE
+
+{% for key, value in zookeeper_environment.iteritems() %}
+{{key}}={{value}}
+{% endfor %}

--- a/templates/zookeeper.service.j2
+++ b/templates/zookeeper.service.j2
@@ -6,8 +6,7 @@ After=network.target
 
 [Service]
 Type=forking
-Environment='ZOO_LOG_DIR={{ zookeeper_log_dir }}'
-Environment='ZOO_LOG4J_PROP=INFO,ROLLINGFILE'
+EnvironmentFile=/etc/default/zookeeper
 ExecStart={{ zookeeper_dir }}/bin/zkServer.sh start
 ExecStop={{ zookeeper_dir }}/bin/zkServer.sh stop
 Restart=on-failure


### PR DESCRIPTION
This moves the Env Vars from the System.d service script and into a defaults file. As well as adds support for including arbitrary Env Vars. 

Use case for this change was to support setting the JVMFLAGS var for Zookeeper start scripts as well as support for GC and other tunings if needed.