### PR TITLE
Update default version to ZooKeeper 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Java: Java 8
 ## Role Variables
 
     zookeeper_mirror: http://www-eu.apache.org/dist/zookeeper
-    zookeeper_version: 3.5.6
+    zookeeper_version: 3.6.0
     zookeeper_package: apache-zookeeper-{{ zookeeper_version }}-bin.tar.gz
     zookeeper_group: zookeeper
     zookeeper_user: zookeeper

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 zookeeper_mirror: https://www-eu.apache.org/dist/zookeeper
-zookeeper_version: 3.5.6
+zookeeper_version: 3.6.0
 zookeeper_package: apache-zookeeper-{{ zookeeper_version }}-bin.tar.gz
 
 zookeeper_group: zookeeper

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,11 +3,6 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
-  options:
-    config-data:
-      ignore: '**/lib/'
 platforms:
   - name: zookeeper-1
     image: centos:7
@@ -17,15 +12,14 @@ platforms:
       - zookeeper-nodes
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
+  lint: |
+    set -e
+    yamllint .
+    ansible-lint
+    flake8
   inventory:
     host_vars:
       zookeeper-1:
         zookeeper_id: 1
 scenario:
   name: default
-verifier:
-  name: testinfra
-  lint:
-    name: flake8

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -2,3 +2,9 @@
 - name: Prepare
   hosts: all
   gather_facts: false
+
+  pre_tasks:
+    - name: Install Java 8 (OpenJDK)
+      yum:
+        name: java-1.8.0-openjdk
+        state: installed


### PR DESCRIPTION
- install ZooKeeper 3.6.0 by default
- install OpenJDK 8 as a dependency for of ZooKeeper for running Molecule unit testing
- updated configuration for linting for Molecule 3