### PR TITLE
Use default zookeeper_id if no host variable provided

### DIFF
--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -48,5 +48,5 @@ clientPort={{ zookeeper_client_port }}
 #server.2=hostname2:2888:3888
 
 {% for host in zookeeper_servers %}
-server.{{ hostvars[host].zookeeper_id }}={{ hostvars[host]['ansible_nodename'] }}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
+server.{{ hostvars[host].zookeeper_id | default(zookeeper_id) }}={{ hostvars[host]['ansible_nodename'] }}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
 {% endfor %}


### PR DESCRIPTION
Fix for #5 to provide default zookeeper_id value in the zoo.cfg configuration file if this is not provided as a host variable.