### PR TITLE
Update default version to ZooKeeper 3.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Java: Java 8
 ## Role Variables
 
     zookeeper_mirror: http://www-eu.apache.org/dist/zookeeper
-    zookeeper_version: 3.6.0
+    zookeeper_version: 3.6.2
     zookeeper_package: apache-zookeeper-{{ zookeeper_version }}-bin.tar.gz
     zookeeper_group: zookeeper
     zookeeper_user: zookeeper

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 zookeeper_mirror: https://www-eu.apache.org/dist/zookeeper
-zookeeper_version: 3.6.0
+zookeeper_version: 3.6.2
 zookeeper_package: apache-zookeeper-{{ zookeeper_version }}-bin.tar.gz
 
 zookeeper_group: zookeeper


### PR DESCRIPTION
Install ZooKeeper 3.6.2 as the default version.