### PR TITLE
Fix myid user/group perm and improve zookeeper_servers variable handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/sleighzy/ansible-zookeeper.svg?branch=master)](https://travis-ci.org/sleighzy/ansible-zookeeper)
 
-Ansible role for installing and configuring Apache ZooKeeper on RHEL / CentOS 7.
+Ansible role for installing and configuring Apache ZooKeeper on RedHat 7 and 8.
 
 This role can be used to install and cluster multiple ZooKeeper nodes, this uses
 all hosts defined for the "zookeeper-nodes" group in the inventory file by
@@ -11,7 +11,7 @@ election ports.
 
 ## Requirements
 
-Platform: RHEL / CentOS 7
+Platform: RedHat 7 and 8
 
 Java: Java 8
 
@@ -32,7 +32,7 @@ Java: Java 8
     zookeeper_id: 1
     zookeeper_leader_port: 2888
     zookeeper_election_port: 3888
-    zookeeper_servers: "{{groups['zookeeper-nodes']}}"
+    zookeeper_servers: zookeeper-nodes
     zookeeper_environment:
         "JVMFLAGS": "-javaagent:/opt/jolokia/jolokia-jvm-1.6.0-agent.jar"
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -3,6 +3,7 @@ zookeeper_mirror: https://www-eu.apache.org/dist/zookeeper
 zookeeper_version: 3.6.2
 zookeeper_package: apache-zookeeper-{{ zookeeper_version }}-bin.tar.gz
 
+zookeeper_create_user_group: true
 zookeeper_group: zookeeper
 zookeeper_user: zookeeper
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -3,6 +3,7 @@
   group:
     name: '{{ zookeeper_group }}'
     state: present
+  when: zookeeper_create_user_group|bool == true
   tags:
     - zookeeper_group
 
@@ -12,6 +13,7 @@
     group: '{{ zookeeper_group }}'
     state: present
     createhome: no
+  when: zookeeper_create_user_group|bool == true
   tags:
     - zookeeper_user
 
@@ -54,6 +56,32 @@
   file:
     src: '{{ zookeeper_install_dir }}'
     dest: '{{ zookeeper_dir }}'
+    state: link
+    group: '{{ zookeeper_group }}'
+    owner: '{{ zookeeper_user }}'
+  tags:
+    - zookeeper_dirs
+
+- name: Remove directory of ZooKeeper application logs
+  file:
+    path: '{{ zookeeper_install_dir }}/logs'
+    state: absent
+  tags:
+    - zookeeper_dirs
+
+- name: Create directory for ZooKeeper application logs
+  file:
+    path: '{{ zookeeper_log_dir }}'
+    state: directory
+    group: '{{ zookeeper_group }}'
+    owner: '{{ zookeeper_user }}'
+  tags:
+    - zookeeper_dirs
+
+- name: Create symlink to ZooKeeper application logs
+  file:
+    src: '{{ zookeeper_log_dir }}'
+    dest: '{{ zookeeper_install_dir }}/logs'
     state: link
     group: '{{ zookeeper_group }}'
     owner: '{{ zookeeper_user }}'
@@ -120,6 +148,8 @@
   template:
     src: myid.j2
     dest: '{{ zookeeper_data_dir }}/myid'
+    group: '{{ zookeeper_group }}'
+    owner: '{{ zookeeper_user }}'
   notify:
     - Restart ZooKeeper service
   tags:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -3,7 +3,7 @@
   group:
     name: '{{ zookeeper_group }}'
     state: present
-  when: zookeeper_create_user_group|bool == true
+  when: zookeeper_create_user_group | bool
   tags:
     - zookeeper_group
 
@@ -13,7 +13,7 @@
     group: '{{ zookeeper_group }}'
     state: present
     createhome: no
-  when: zookeeper_create_user_group|bool == true
+  when: zookeeper_create_user_group | bool
   tags:
     - zookeeper_user
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -62,32 +62,6 @@
   tags:
     - zookeeper_dirs
 
-- name: Remove directory of ZooKeeper application logs
-  file:
-    path: '{{ zookeeper_install_dir }}/logs'
-    state: absent
-  tags:
-    - zookeeper_dirs
-
-- name: Create directory for ZooKeeper application logs
-  file:
-    path: '{{ zookeeper_log_dir }}'
-    state: directory
-    group: '{{ zookeeper_group }}'
-    owner: '{{ zookeeper_user }}'
-  tags:
-    - zookeeper_dirs
-
-- name: Create symlink to ZooKeeper application logs
-  file:
-    src: '{{ zookeeper_log_dir }}'
-    dest: '{{ zookeeper_install_dir }}/logs'
-    state: link
-    group: '{{ zookeeper_group }}'
-    owner: '{{ zookeeper_user }}'
-  tags:
-    - zookeeper_dirs
-
 - name: Create directory for snapshot files and myid file
   file:
     path: '{{ zookeeper_data_dir }}'

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -47,6 +47,6 @@ clientPort={{ zookeeper_client_port }}
 #server.1=hostname1:2888:3888
 #server.2=hostname2:2888:3888
 
-{% for host in zookeeper_servers %}
-server.{{ hostvars[host].zookeeper_id | default(zookeeper_id) }}={{ hostvars[host]['ansible_nodename'] }}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
+{% for host in groups[zookeeper_servers] %}
+server.{{ hostvars[host].zookeeper_id | default(zookeeper_id) }}={{ hostvars[host].ansible_nodename }}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
 {% endfor %}


### PR DESCRIPTION
I have also moved the logs from the installation folder to /var/log. This will be better when you have a LVM partition just for /var/log, so when it gets full, it doesn't break anything.