### PR TITLE
Add Github actions for linting files

### DIFF
--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -1,0 +1,28 @@
+---
+name: Ansible Lint
+
+#
+# Documentation:
+# https://github.com/ansible/ansible-lint-action
+#
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Ansible Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Lint Ansible Role
+        uses: ansible/ansible-lint-action@master
+        with:
+          targets: ''

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,0 +1,32 @@
+---
+name: Lint Code Base
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Linter
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          DEFAULT_BRANCH: master
+          FILTER_REGEX_EXCLUDE: .*(tests/|Dockerfile.j2).*
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINTER_RULES_PATH: /
+          MARKDOWN_CONFIG_FILE: .markdownlint.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ include/
 lib/
 molecule/default/tests/__pycache__
 share/
+
+super-linter.log

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,9 +1,13 @@
 {
+  "line-length": {
+    "code_blocks": false,
+    "tables": false
+  },
   "list-marker-space": {
     "ol_single": 2,
     "ol_multi": 2
   },
-  "line-length": {
-    "code_blocks": false
+  "no-inline-html": {
+    "allowed_elements": ["br"]
   }
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "davidanson.vscode-markdownlint",
+    "esbenp.prettier-vscode",
+    "timonwong.shellcheck"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Apache ZooKeeper
 
 [![Build Status](https://travis-ci.org/sleighzy/ansible-zookeeper.svg?branch=master)](https://travis-ci.org/sleighzy/ansible-zookeeper)
+![Lint Code Base](https://github.com/sleighzy/ansible-zookeeper/workflows/Lint%20Code%20Base/badge.svg)
+![Ansible Lint](https://github.com/sleighzy/ansible-zookeeper/workflows/Ansible%20Lint/badge.svg)
 
 Ansible role for installing and configuring Apache ZooKeeper on RedHat 7 and 8.
 
@@ -17,24 +19,25 @@ Java: Java 8
 
 ## Role Variables
 
-    zookeeper_mirror: http://www-eu.apache.org/dist/zookeeper
-    zookeeper_version: 3.6.2
-    zookeeper_package: apache-zookeeper-{{ zookeeper_version }}-bin.tar.gz
-    zookeeper_group: zookeeper
-    zookeeper_user: zookeeper
-    zookeeper_root_dir: /usr/share
-    zookeeper_install_dir: '{{ zookeeper_root_dir}}/apache-zookeeper-{{zookeeper_version}}'
-    zookeeper_dir: '{{ zookeeper_root_dir }}/zookeeper'
-    zookeeper_log_dir: /var/log/zookeeper
-    zookeeper_data_dir: /var/lib/zookeeper
-    zookeeper_data_log_dir: /var/lib/zookeeper
-    zookeeper_client_port: 2181
-    zookeeper_id: 1
-    zookeeper_leader_port: 2888
-    zookeeper_election_port: 3888
-    zookeeper_servers: zookeeper-nodes
-    zookeeper_environment:
-        "JVMFLAGS": "-javaagent:/opt/jolokia/jolokia-jvm-1.6.0-agent.jar"
+| Variable                | Default                                                           |
+| ----------------------- | ----------------------------------------------------------------- |
+| zookeeper_mirror        | <http://www-eu.apache.org/dist/zookeeper>                         |
+| zookeeper_version       | 3.6.2                                                             |
+| zookeeper_package       | apache-zookeeper-{{ zookeeper_version }}-bin.tar.gz               |
+| zookeeper_group         | zookeeper                                                         |
+| zookeeper_user          | zookeeper                                                         |
+| zookeeper_root_dir      | /usr/share                                                        |
+| zookeeper_install_dir   | '{{ zookeeper_root_dir}}/apache-zookeeper-{{zookeeper_version}}'  |
+| zookeeper_dir           | '{{ zookeeper_root_dir }}/zookeeper'                              |
+| zookeeper_log_dir       | /var/log/zookeeper                                                |
+| zookeeper_data_dir      | /var/lib/zookeeper                                                |
+| zookeeper_data_log_dir  | /var/lib/zookeeper                                                |
+| zookeeper_client_port   | 2181                                                              |
+| zookeeper_id            | 1                                                                 |
+| zookeeper_leader_port   | 2888                                                              |
+| zookeeper_election_port | 3888                                                              |
+| zookeeper_servers       | zookeeper-nodes                                                   |
+| zookeeper_environment   | "JVMFLAGS": "-javaagent:/opt/jolokia/jolokia-jvm-1.6.0-agent.jar" |
 
 ### Default Ports
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -36,6 +36,7 @@
     state: directory
     group: '{{ zookeeper_group }}'
     owner: '{{ zookeeper_user }}'
+    mode: 0755
   when: not dir.stat.exists
   tags:
     - zookeeper_dirs
@@ -68,6 +69,7 @@
     state: directory
     group: '{{ zookeeper_group }}'
     owner: '{{ zookeeper_user }}'
+    mode: 0755
   tags:
     - zookeeper_dirs
 
@@ -77,6 +79,7 @@
     state: directory
     group: '{{ zookeeper_group }}'
     owner: '{{ zookeeper_user }}'
+    mode: 0755
   tags:
     - zookeeper_dirs
 
@@ -86,6 +89,7 @@
     state: directory
     group: '{{ zookeeper_group }}'
     owner: '{{ zookeeper_user }}'
+    mode: 0755
   tags:
     - zookeeper_dirs
 
@@ -94,6 +98,9 @@
   template:
     src: zoo.cfg.j2
     dest: '{{ zookeeper_dir }}/conf/zoo.cfg'
+    group: '{{ zookeeper_group }}'
+    owner: '{{ zookeeper_user }}'
+    mode: 0644
   notify:
     - Restart ZooKeeper service
   tags:
@@ -105,6 +112,7 @@
     state: directory
     group: '{{ zookeeper_group }}'
     owner: '{{ zookeeper_user }}'
+    mode: 0755
   tags:
     - zookeeper_config
 
@@ -124,6 +132,7 @@
     dest: '{{ zookeeper_data_dir }}/myid'
     group: '{{ zookeeper_group }}'
     owner: '{{ zookeeper_user }}'
+    mode: 0644
   notify:
     - Restart ZooKeeper service
   tags:
@@ -133,6 +142,9 @@
   template:
     src: default.j2
     dest: '/etc/default/zookeeper'
+    group: '{{ zookeeper_group }}'
+    owner: '{{ zookeeper_user }}'
+    mode: 0644
   notify:
     - Restart ZooKeeper service
   tags:
@@ -153,6 +165,9 @@
   template:
     src: zookeeper.service.j2
     dest: /usr/lib/systemd/system/zookeeper.service
+    group: '{{ zookeeper_group }}'
+    owner: '{{ zookeeper_user }}'
+    mode: 0644
   notify:
     - Restart ZooKeeper service
   tags:

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -47,6 +47,6 @@ clientPort={{ zookeeper_client_port }}
 #server.1=hostname1:2888:3888
 #server.2=hostname2:2888:3888
 
-{% for host in groups[zookeeper_servers] %}
+{% for host in zookeeper_servers %}
 server.{{ hostvars[host].zookeeper_id | default(zookeeper_id) }}={{ hostvars[host].ansible_nodename }}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
 {% endfor %}


### PR DESCRIPTION
Github Actions added for linting codebase:

- the Github super-linter is used for linting files
- the ansible-lint-action is used to lint the Ansible role files