### PR TITLE
Use ipam_config for Docker network in tests

### DIFF
--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -8,13 +8,13 @@
     - name: Create Docker network
       docker_network:
         name: zookeeper
-        ipam_options:
+        ipam_config:
           subnet: '172.25.0.0/16'
 
     # The centos/systemd image used to create these containers is required so
     # that systemd is available. This is used for the systemctl commands to
     # install and run the zookeeper services for this role. The privileged container
-    # and "/sys/fs/cgroup" volume mount is also requird for systemd support.
+    # and "/sys/fs/cgroup" volume mount is also required for systemd support.
     # Port 2181 is exposed as the ZooKeeper port.
     # The container needs to be started with the "/usr/lib/systemd/systemd" so that
     # this service is initialized.


### PR DESCRIPTION
The ipam_options for Docker network used in the Travis tests was deprecated in Ansible 2.8.
This has now been removed as ipam_config should be used instead. Using ipam_options causes
Travis-CI build failures when running the tests.