### PR TITLE
Upgrade to Apache ZooKeeper 3.7.0

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-lint yamllint docker molecule[docker,lint]
+        run: pip3 install ansible ansible-lint yamllint docker molecule-docker molecule[docker,lint]
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 # General file ignores
 .DS_Store
 
+# Symlink to current repository to enable Ansible to find the role
+# using its expected full name for Molecule tests
+.cache/
+
+# Python virtual env for Molecule testing
 molecule-venv/
-molecule/default/tests/__pycache__
 
 super-linter.log
 .vscode

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ election ports.
 
 Java: Java 8 / 11
 
+Ansible 2.9.16 or 2.10.4 are the minimum required versions to workaround an
+issue with certain kernels that have broken the `systemd` status check. The
+error message "`Service is in unknown state`" will be output when attempting to
+start the service via the Ansible role and the task will fail. The service will
+start as expected if the `systemctl start` command is run on the physical host.
+See <https://github.com/ansible/ansible/issues/71528> for more information.
+
 ## Role Variables
 
 | Variable                | Default                                                           |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ election ports.
 - RedHat 7
 - RedHat 8
 - Ubuntu 18.04.x
+- Ubuntu 20.04.x
 
 ## Requirements
 
@@ -100,10 +101,15 @@ As per the [Molecule Installation guide] this should be done using a virtual
 environment. The commands below will create a Python virtual environment and
 install Molecule including the Docker driver.
 
+_Note:_ Due to a breaking change in Molecule 3.1.1 the Docker driver for
+Molecule has been removed and the `molecule-driver` module must be installed
+separately.
+
 ```sh
 $ python3 -m venv molecule-venv
 $ source molecule-venv/bin/activate
-(molecule-venv) $ python3 -m pip install --user "molecule[docker,lint]"
+(molecule-venv) $ python3 -m pip install molecule-docker
+(molecule-venv) $ python3 -m pip install "molecule[docker,lint]"
 ```
 
 Run playbook and tests. Linting errors need to be corrected before Molecule will

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See <https://github.com/ansible/ansible/issues/71528> for more information.
 | Variable                | Default                                                           |
 | ----------------------- | ----------------------------------------------------------------- |
 | zookeeper_mirror        | <http://www-eu.apache.org/dist/zookeeper>                         |
-| zookeeper_version       | 3.6.2                                                             |
+| zookeeper_version       | 3.7.0                                                             |
 | zookeeper_package       | apache-zookeeper-{{ zookeeper_version }}-bin.tar.gz               |
 | zookeeper_group         | zookeeper                                                         |
 | zookeeper_user          | zookeeper                                                         |

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,7 +1,7 @@
 ---
 # Installation variables
 
-zookeeper_version: 3.6.2
+zookeeper_version: 3.7.0
 zookeeper_mirror: https://www-eu.apache.org/dist/zookeeper
 zookeeper_package: apache-zookeeper-{{ zookeeper_version }}-bin.tar.gz
 
@@ -23,25 +23,25 @@ zookeeper_restart: yes
 
 # Configuration variables
 
-# The unit of time for ZooKeeper translated to milliseconds. 
-# This governs all ZooKeeper time dependent operations. It is used for heartbeats and timeouts especially. 
+# The unit of time for ZooKeeper translated to milliseconds.
+# This governs all ZooKeeper time dependent operations. It is used for heartbeats and timeouts especially.
 # Note that the minimum session timeout will be two ticks.
 zookeeper_ticktime: 3000
 
-# Amount of time, in ticks (see tickTime), to allow followers to connect and sync to a leader. 
+# Amount of time, in ticks (see tickTime), to allow followers to connect and sync to a leader.
 # Increased this value as needed, if the amount of data managed by ZooKeeper is large.
 zookeeper_init_limit: 10
 
-# Amount of time, in ticks (see tickTime), to allow followers to sync with ZooKeeper. 
+# Amount of time, in ticks (see tickTime), to allow followers to sync with ZooKeeper.
 # If followers fall too far behind a leader, they will be dropped.
 zookeeper_sync_limit: 5
 
-# The directory where ZooKeeper in-memory database snapshots and, unless specified in dataLogDir, the transaction log of updates to the database. 
-# This location should be a dedicated disk that is ideally an SSD. 
+# The directory where ZooKeeper in-memory database snapshots and, unless specified in dataLogDir, the transaction log of updates to the database.
+# This location should be a dedicated disk that is ideally an SSD.
 # For more information, see the ZooKeeper Administration Guide (https://zookeeper.apache.org/doc/current/zookeeperAdmin.html).
 zookeeper_data_dir: /var/lib/zookeeper
-# The location where the transaction log is written to. If you don’t specify this option, the log is written to dataDir. 
-# By specifying this option, you can use a dedicated log device, and help avoid competition between logging and snapshots. 
+# The location where the transaction log is written to. If you don’t specify this option, the log is written to dataDir.
+# By specifying this option, you can use a dedicated log device, and help avoid competition between logging and snapshots.
 # For more information, see the ZooKeeper Administration Guide (https://zookeeper.apache.org/doc/current/zookeeperAdmin.html).
 zookeeper_data_log_dir: /var/lib/zookeeper
 
@@ -51,7 +51,7 @@ zookeeper_client_port: 2181
 # The maximum allowed number of client connections for a ZooKeeper server. To avoid running out of allowed connections set this to 0 (unlimited).
 zookeeper_max_client_cnxns: 60
 
-# When enabled, ZooKeeper auto purge feature retains the autopurge.snapRetainCount most recent snapshots and the corresponding transaction logs 
+# When enabled, ZooKeeper auto purge feature retains the autopurge.snapRetainCount most recent snapshots and the corresponding transaction logs
 # in the dataDir and dataLogDir respectively and deletes the rest.
 zookeeper_autopurge_snap_retain_count: 3
 # The time interval in hours for which the purge task has to be triggered. Set to a positive integer (1 and above) to enable the auto purging.
@@ -70,7 +70,7 @@ zookeeper_enable_server: yes
 # The address the embedded Jetty server listens on. Defaults to 0.0.0.0.
 zookeeper_server_address: 0.0.0.0
 # The port the embedded Jetty server listens on. Defaults to 8080.
-zookeeper_server_port: 8080 
+zookeeper_server_port: 8080
 # Set the maximum idle time in milliseconds that a connection can wait before sending or receiving data. Defaults to 30000 ms.
 zookeeper_idle_timeout: 30000
 # The URL for listing and issuing commands relative to the root URL. Defaults to "/commands".

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Simon Leigh
   description: Apache ZooKeeper installation for RHEL/CentOS and Debian/Ubuntu
   license: MIT
-  min_ansible_version: 2.x
+  min_ansible_version: 2.10.4
   platforms:
     - name: EL
       versions:
@@ -15,6 +15,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
+        - focal
   galaxy_tags:
     - zookeeper
     - clustering

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,4 +2,4 @@
 - name: Converge
   hosts: all
   roles:
-    - sleighzy.zookeeper
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -54,7 +54,7 @@ platforms:
       - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: '/usr/sbin/init'
+    command: '/usr/lib/systemd/systemd'
     pre_build_image: true
     capabilities:
       - SYS_ADMIN

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -16,12 +16,12 @@
           - "'zookeeper' in getent_passwd"
           - "'zookeeper' in getent_group"
 
-    - name: Register '/usr/share/apache-zookeeper-3.6.2' installation directory status
+    - name: Register '/usr/share/apache-zookeeper-3.7.0' installation directory status
       stat:
-        path: '/usr/share/apache-zookeeper-3.6.2'
+        path: '/usr/share/apache-zookeeper-3.7.0'
       register: install_dir
 
-    - name: Assert that '/usr/share/apache-zookeeper-3.6.2' directory is created
+    - name: Assert that '/usr/share/apache-zookeeper-3.7.0' directory is created
       assert:
         that:
           - install_dir.stat.exists
@@ -39,7 +39,7 @@
         that:
           - zookeeper_dir.stat.exists
           - zookeeper_dir.stat.islnk
-          - zookeeper_dir.stat.lnk_target == '/usr/share/apache-zookeeper-3.6.2'
+          - zookeeper_dir.stat.lnk_target == '/usr/share/apache-zookeeper-3.7.0'
 
     - name: Register '/etc/zookeeper' directory status
       stat:


### PR DESCRIPTION
Upgrade to the Apache ZooKeeper 3.7.0 release

Additional changes:

*  Some kernel versions have made breaking changes to the attributes
    returned in systemd service calls that Ansible uses to determine what
    state the service is in. Ansible 2.9.16 and 2.10.4 are the minimum
    required versions as a workaround was put in place to use different
    commands to retrieve the service status.

*  A breaking change in Molecule 3.1.1 removed the Docker driver.
    This must be installed separately using the pip molecule-docker
    module.

*  Ubuntu 20.04 LTS listed as supported platform