### PR TITLE
Use default zookeeper_id value if not provided for the host

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-lint yamllint docker molecule-docker molecule[docker,lint]
+        run: pip3 install ansible ansible-lint yamllint docker molecule-docker "molecule[docker,lint]"
 
       - name: Run Molecule tests.
         run: molecule test

--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ separately.
 ```sh
 $ python3 -m venv molecule-venv
 $ source molecule-venv/bin/activate
-(molecule-venv) $ python3 -m pip install molecule-docker
-(molecule-venv) $ python3 -m pip install "molecule[docker,lint]"
+(molecule-venv) $ python3 -m pip install ansible ansible-lint yamllint docker molecule-docker "molecule[docker,lint]"
 ```
 
 Run playbook and tests. Linting errors need to be corrected before Molecule will

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -64,8 +64,9 @@ provisioner:
   name: ansible
   inventory:
     host_vars:
+      # The zookeeper_id is not provided for zookeeper-1 as this
+      # should use the value of 1 from the defaults.
       zookeeper-1:
-        zookeeper_id: 1
       zookeeper-2:
         zookeeper_id: 2
       zookeeper-3:

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -45,7 +45,7 @@ autopurge.purgeInterval={{ zookeeper_purge_interval }}
 # Each server also needs a /var/lib/zookeeper/myid file created containing
 # a single unique number, e.g. 1, 2, etc.
 {% for host in zookeeper_servers %}
-server.{{ hostvars[host].zookeeper_id }}={{ hostvars[host].ansible_nodename }}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
+server.{{ hostvars[host].zookeeper_id | default(zookeeper_id) }}={{ hostvars[host].ansible_nodename }}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
 {% endfor %}
 
 {% if zookeeper_version is version('3.5', '>=') %}


### PR DESCRIPTION
If the zookeeper_id variable is not provided for a host then the default value for the
Ansible role needs to be used.

Fixes #20