### PR TITLE
Create user and group as system user/group

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -12,6 +12,7 @@
   group:
     name: "{{ zookeeper_group }}"
     state: present
+    system: yes
   when: zookeeper_create_user_group | bool
   tags:
     - zookeeper_group
@@ -22,6 +23,7 @@
     group: "{{ zookeeper_group }}"
     state: present
     createhome: no
+    system: yes
   when: zookeeper_create_user_group | bool
   tags:
     - zookeeper_user


### PR DESCRIPTION
Setting this only influences new installs where the user and/or group doesn't exist.

I would have liked to also define the users HOME to `zookeeper_dir` or `/nonexistent` (used by at least Debian for system users where HOME doesn't really make sense), but that would fail when the user all ready exists because he would usually have a running process. 