### PR TITLE
Add namespace and role name to Galaxy info

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,7 @@
 ---
 galaxy_info:
+  namespace: sleighzy
+  role_name: zookeeper
   author: Simon Leigh
   description: Apache ZooKeeper installation for RHEL/CentOS and Debian/Ubuntu
   license: MIT


### PR DESCRIPTION
The namespace and role name are required as Ansible Galaxy v3.0 does not
alter the GitHub repository name when importing the role so this needs
to be done explicitly.

This resolves the issue where this is tested for by Molecule which would
have produced the below error.

ERROR    Computed fully qualified role name of zookeeper does not follow current galaxy requirements.