### PR TITLE
Skip log4j configuration when ZooKeeper version is >= 3.8

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,4 +1,9 @@
 ---
+- name: Set zookeeper version variables
+  set_fact:
+    zookeeper_version_major: "{{ zookeeper_version.split('.')[0] }}"
+    zookeeper_version_minor: "{{ zookeeper_version.split('.')[1] }}"
+
 - name: Load OS-specific variables
   include_vars: "{{ item }}"
   with_first_found:
@@ -171,6 +176,7 @@
     - Restart ZooKeeper service
   tags:
     - zookeeper_config
+  when: zookeeper_version_major|int == 3 and zookeeper_version_minor|int < 8
 
 - name: Template ZooKeeper systemd service file
   template:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Set zookeeper version variables
-  set_fact:
+  ansible.builtin.set_fact:
     zookeeper_version_major: "{{ zookeeper_version.split('.')[0] }}"
     zookeeper_version_minor: "{{ zookeeper_version.split('.')[1] }}"
 


### PR DESCRIPTION
ZooKeeper migrated from `log4j` to `logback` (See https://issues.apache.org/jira/browse/ZOOKEEPER-4427). Because of this, the "Set maximum log rollover history" task fails when trying to install ZooKeeper 3.8.0. This PR skips said task when ZooKeeper >= 3.8 is requrested.


.

