### PR TITLE
Add workflow_dispatch to GitHub action

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -10,6 +10,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 defaults:
   run:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apache ZooKeeper
 
 [![Build Status]](https://travis-ci.org/sleighzy/ansible-zookeeper)
-![Lint Code Base] ![Ansible Lint] ![Molecule]
+![Lint Code Base] ![Molecule]
 
 Ansible role for installing and configuring Apache ZooKeeper
 
@@ -167,8 +167,6 @@ molecule destroy
 
 [![MIT license]](https://lbesson.mit-license.org/)
 
-[ansible lint]:
-  https://github.com/sleighzy/ansible-zookeeper/workflows/Ansible%20Lint/badge.svg
 [ansible-lint]: https://docs.ansible.com/ansible-lint/
 [ansible molecule]: https://molecule.readthedocs.io/en/latest/
 [build status]:


### PR DESCRIPTION
Added the `workflow_dispatch` to the GitHub actions so that the workflow can be manually triggered.

https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs