### PR TITLE
Allow optional variable to use inventory_hostname instead of ansible_hostname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ molecule-venv/
 
 super-linter.log
 .vscode
+
+*.iml

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -66,6 +66,7 @@ zookeeper_id: 1
 zookeeper_leader_port: 2888
 zookeeper_election_port: 3888
 zookeeper_servers: "{{ groups['zookeeper-nodes'] }}"
+zookeeper_use_servers_inventory_hostname: false
 zookeeper_environment: {}
 
 # Set to "false" to disable the AdminServer. By default the AdminServer is enabled.

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -66,7 +66,7 @@ zookeeper_id: 1
 zookeeper_leader_port: 2888
 zookeeper_election_port: 3888
 zookeeper_servers: "{{ groups['zookeeper-nodes'] }}"
-zookeeper_use_servers_inventory_hostname: false
+zookeeper_servers_use_inventory_hostname: false
 zookeeper_environment: {}
 
 # Set to "false" to disable the AdminServer. By default the AdminServer is enabled.

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -45,7 +45,9 @@ autopurge.purgeInterval={{ zookeeper_purge_interval }}
 # Each server also needs a /var/lib/zookeeper/myid file created containing
 # a single unique number, e.g. 1, 2, etc.
 {% for host in zookeeper_servers %}
-server.{{ hostvars[host].zookeeper_id | default(zookeeper_id) }}={{ hostvars[host].ansible_nodename }}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
+server.{{ hostvars[host].zookeeper_id | default(zookeeper_id) }}={{
+host if zookeeper_use_servers_inventory_hostname else hostvars[host].ansible_nodename
+}}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
 {% endfor %}
 
 {% if zookeeper_version is version('3.5', '>=') %}

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -46,7 +46,7 @@ autopurge.purgeInterval={{ zookeeper_purge_interval }}
 # a single unique number, e.g. 1, 2, etc.
 {% for host in zookeeper_servers %}
 server.{{ hostvars[host].zookeeper_id | default(zookeeper_id) }}={{
-host if zookeeper_use_servers_inventory_hostname else hostvars[host].ansible_nodename
+host if zookeeper_servers_use_inventory_hostname else hostvars[host].ansible_nodename
 }}:{{ zookeeper_leader_port }}:{{ zookeeper_election_port }}
 {% endfor %}
 


### PR DESCRIPTION
This PR includes a README to explain the issue that I encountered with this role. 

I've dded an optional parameter(that defaults to false to preserve current behaviour) where the hostname used in the server list is used. This happens when the the host only gives its hostname instead of its FQDN(Fully Qualified Domain Name). This can cause the server being unable to see each other. 

Also, this could be required if you want/need to use TLS since the hostname needs to match the certificate it presents