### PR TITLE
Install the ps command onto Rocky for the Molecule tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ install Molecule including the Docker driver.
 ```sh
 $ python3 -m venv molecule-venv
 $ source molecule-venv/bin/activate
-(molecule-venv) $ python3 -m pip3 install ansible docker "molecule-plugins[docker]"
+(molecule-venv) $ pip3 install ansible docker "molecule-plugins[docker]"
 ```
 
 Run playbook and tests. Linting errors need to be corrected before Molecule will

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -24,7 +24,7 @@
           - python-firewall
           - firewalld
         state: installed
-      when: ansible_distribution == "CentOs" and ansible_distribution_major_version == "7"
+      when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
 
     - name: Install Java 11 (OpenJDK) on Debian
       ansible.builtin.apt:
@@ -33,7 +33,7 @@
         update_cache: yes
       when: ansible_os_family == "Debian"
 
-    # The installation of this package into the Debian container means
+    # The installation of this package into the container means
     # that the "ps" command is available for viewing the running process.
     # Installing this package however also prevents an issue whereby the
     # ZooKeeper service is constantly restarted by systemd which causes
@@ -43,3 +43,10 @@
         name: procps
         state: present
       when: ansible_os_family == "Debian"
+
+    - name: Install ps on Rocky Linux
+      ansible.builtin.yum:
+        name: procps
+        state: present
+        use_backend: dnf
+      when: ansible_distribution == "Rocky" and ansible_distribution_major_version == "8"


### PR DESCRIPTION
The `ps` command needs to be installed so that Rocky Linux (or any system needing `ps`) can detect that ZooKeeper is running. If this is not present then the system reports that ZooKeeper is not running, even when it is. It will continue to attempt to restart due to failures, which will also fail as ZooKeeper is actually running and the ports are currently in use.