### PR TITLE
Fix suggestion: remove faulty symlink that causes installation fail

### DIFF
--- a/tests/roles/ansible-zookeeper
+++ b/tests/roles/ansible-zookeeper
@@ -1,1 +1,0 @@
-../../../ansible-zookeeper


### PR DESCRIPTION
ansible-core 2.15.9 introduces tar filepath normalization and current symlink is inconsistent to that.

See more details https://github.com/ansible/ansible/blob/080b5103bef75c4a1d19d576ea8ebf49e149b48b/changelogs/CHANGELOG-v2.15.rst#L34C195-L34C242

I'm not sure if this symlink is still relevant and if so, what should be the replacement for it. Please advice or merge and release fixed version.